### PR TITLE
chore: enable public ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - '8'
+  - 'node'
+after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > Reusable validation logic as pure functions
 
+[![Build Status](https://travis-ci.org/itenneti/stateless-validation.svg?branch=master)](https://travis-ci.org/itenneti/stateless-validation)
+[![Coverage Status](https://coveralls.io/repos/github/itenneti/stateless-validation/badge.svg?branch=master)](https://coveralls.io/github/itenneti/stateless-validation?branch=master)
+[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
 This package allows us to reuse the same validation logic between the UI/frontend and the REST API/backend.
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "prepare": "babel src -d lib",
     "pretest": "standard && npm run prepare",
-    "test": "tap test.js --100",
+    "test": "tap --cov test.js",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "standard-version"
   },
   "repository": {
@@ -28,6 +29,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "coveralls": "^3.0.0",
     "standard": "^10.0.3",
     "standard-version": "^4.2.0",
     "tap": "^10.7.3"


### PR DESCRIPTION
Fixes #5

1. Made this repo public
2. Enabled [Travis](https://travis-ci.org/itenneti/stateless-validation) and [Coveralls](https://coveralls.io/github/itenneti/stateless-validation) for this repo
3. Configured Coveralls token in Travis settings
4. Added `.travis.yml` file (to run tests on Node 8 and whatever version is latest)
5. Added `npm run coverage` script to package.json
6. Added badges to README for:
    - Travis build status
    - Coveralls coverage status
    - JS Standard style
    - Conventional commits